### PR TITLE
BA Searcher Failing on Stopovers Page

### DIFF
--- a/src/engines/ba/searcher.js
+++ b/src/engines/ba/searcher.js
@@ -116,7 +116,10 @@ module.exports = class extends Searcher {
 
       // Check for stopover form
       if (await page.$('#noStopovers')) {
-        await page.click('#noStopovers')
+        await page.evaluate(() => {
+          var noStopovers = document.querySelector('#noStopovers')
+          noStopovers.click();
+        })
         await page.waitFor(500)
         await this.clickAndWait('#continueTopPod')
         continue


### PR DESCRIPTION
When searching ba flights, puppeteer would throw an error when trying to click on the '#noStopovers' radio button. Looking online it seems for radio buttons it is safer to query for that element and then calling 'click' on the element as opposed to 'page.click'.