### PR TITLE
Cannot filter by flight number

### DIFF
--- a/client/src/stores/searchStore.js
+++ b/client/src/stores/searchStore.js
@@ -83,6 +83,8 @@ export default class SearchStore {
             )
           }).join(' ')
         }
+
+        result.segments.forEach(x => x.aircraft = x.aircraft || 'Unknown Aircraft')
         return { ...result, fares }
       })
   }
@@ -95,13 +97,17 @@ export default class SearchStore {
       return !result.segments.find(x => !this.getAirline(x.airline))
     }
     const filteredByFlight = (result) => {
+      return !result.segments.find(x => !this.getFlight(x))
+    }
+    const mapedFlight = (result) => {
       return (result.segments.find(x => !this.getFlight(x)))
         ? { ...result, fares: '' }
         : result
     }
     return this.results
       .filter(x => filteredByAirline(x))
-      .map(x => filteredByFlight(x))
+      .filter(x => filteredByFlight(x))
+      .map(x => mapedFlight(x))
   }
 
   @computed get aircraftInfo () {

--- a/client/src/stores/searchStore.js
+++ b/client/src/stores/searchStore.js
@@ -264,9 +264,15 @@ export default class SearchStore {
     sel.set(key, val)
 
     // Propagate to airlines
-    if (val) {
-      this.selectedAirlines.set(flight.airline, true)
-    }
+    const { flights } = this
+    const context = this
+    this.airlines
+      .map(x => x.code)
+      .forEach(x => {
+        const isAirlineSelected = flights.filter(y => y.airline === x).some(z => context.getFlight(z))
+        context.selectedAirlines.set(x, isAirlineSelected)
+      })
+
   }
 
   @action update (params) {


### PR DESCRIPTION
Fixed the issue with the flight number filter. The flight key was being formed incorrectly when trying to determine if a particular segment was selected or not.