### PR TITLE
Fixed a bug with the BA parser that was throwing an exception if the …

### DIFF
--- a/src/engines/ba/parser.js
+++ b/src/engines/ba/parser.js
@@ -85,14 +85,22 @@ module.exports = class extends Parser {
   }
 
   parseDate (str, query, outbound) {
-    const m = moment.utc(str, 'D MMM', true)
+    let m = moment.utc(str, 'D MMM', true)
+    
+    // if the moment is invalid and the date string is '29 Feb', then assume that
+    // the leap year is for the next year and re-initialize the moment
+    if(!m.isValid() && str === '29 Feb') {
+      m = moment.utc(`${str} ${new Date().getFullYear() + 1}`, 'D MMM YYYY', true)
+    }
+    
     if (m.isValid()) {
       return outbound
         ? query.closestDeparture(m)
         : query.closestReturn(m)
-    }
+    } 
     return null
   }
+
 
   parseQuantity (ele) {
     if (ele) {


### PR DESCRIPTION
…departure or arrival date was on Feb 29th of the following year. This is because ba.com gives us only the month and date and we validate it against the current year instead of the year it was meant for.